### PR TITLE
Switch the zuul configuration to source from github

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     name: BonnyCI/sandbox-v3
-    gerrithub_check:
+    github_check:
       jobs:
         - bonnyci


### PR DESCRIPTION
We have to have seperate zuul pipelines for github and gerrit for now.
Switch sandbox over to github.

Change-Id: Ife5b1b389b59aceac959b642edc39c8aad01d506
Signed-off-by: Jamie Lennox <jamielennox@gmail.com>